### PR TITLE
Реализовываем анимацию заголовков на экране «Результат игры»

### DIFF
--- a/source/img/lose-heading.svg
+++ b/source/img/lose-heading.svg
@@ -1,193 +1,31 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 220" width="660" height="220">
-  <g>
+  <g class="negativeHeading">
     <path
-      id="n" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M2.66,92V8H16.1V42.2H53.3V8H66.74V92H53.3V58.64H16.1V92H2.66Z"
-    >
-      <animateTransform
-        id="nAppear"
-        attributeName="transform"
-        type="translate"
-        begin="100ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="nAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="n" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M2.66,92V8H16.1V42.2H53.3V8H66.74V92H53.3V58.64H16.1V92H2.66Z"/>
     <path
-      id="e" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M147.62,8V24.44H97V41.6h33.6V58H97V75.56h50.64V92H83.54V8h64.08Z"
-    >
-      <animateTransform
-        id="eAppear"
-        attributeName="transform"
-        type="translate"
-        begin="nAppear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="eAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="e" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M147.62,8V24.44H97V41.6h33.6V58H97V75.56h50.64V92H83.54V8h64.08Z"/>
     <path
-      id="u" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M199.22,8l20.52,42.36L235.34,8h16.44l-31,84H204.38l9.48-25.92L185.78,8h13.44Z"
-    >
-      <animateTransform
-        id="uAppear"
-        attributeName="transform"
-        type="translate"
-        begin="eAppear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="uAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="u" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M199.22,8l20.52,42.36L235.34,8h16.44l-31,84H204.38l9.48-25.92L185.78,8h13.44Z"/>
     <path
-      id="g" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M273.74,24.44V92H260.3V8h50.16V24.44H273.74Z"
-    >
-      <animateTransform
-        id="gAppear"
-        attributeName="transform"
-        type="translate"
-        begin="uAppear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="gAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="g" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M273.74,24.44V92H260.3V8h50.16V24.44H273.74Z"/>
     <path
-      id="a1" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M307.1,92l28-84h27.12l28.08,84H376.82L369,68.48h-37.8L323.42,92H307.1Zm56.64-40L350.3,11.84,336.86,52h26.88Z"
-    >
-      <animateTransform
-        id="a1Appear"
-        attributeName="transform"
-        type="translate"
-        begin="gAppear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="a1Appear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="a1" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M307.1,92l28-84h27.12l28.08,84H376.82L369,68.48h-37.8L323.42,92H307.1Zm56.64-40L350.3,11.84,336.86,52h26.88Z"/>
     <path
-      id="d" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M396.38,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L412.94,8h48.6V75.56h10v34.68H456.86V92H411v18.24H396.38ZM448.1,75.56V24.44H425.54v3.12c-0.48,22.44-3.24,37.68-7.2,48H448.1Z"
-    >
-      <animateTransform
-        id="dAppear"
-        attributeName="transform"
-        type="translate"
-        begin="a1Appear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="dAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="d" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M396.38,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L412.94,8h48.6V75.56h10v34.68H456.86V92H411v18.24H396.38ZM448.1,75.56V24.44H425.54v3.12c-0.48,22.44-3.24,37.68-7.2,48H448.1Z"/>
     <path
-      id="a2" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M477.74,92l28-84h27.12L560.9,92H547.46l-7.8-23.52h-37.8L494.06,92H477.74Zm56.64-40-13.44-40.2L507.5,52h26.88Z"
-    >
-      <animateTransform
-        id="a2Appear"
-        attributeName="transform"
-        type="translate"
-        begin="dAppear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="a2Appear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="a2" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M477.74,92l28-84h27.12L560.9,92H547.46l-7.8-23.52h-37.8L494.06,92H477.74Zm56.64-40-13.44-40.2L507.5,52h26.88Z"/>
     <path
-      id="l" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M568.7,76.88a13.77,13.77,0,0,0,5,1c6.6,0,10.44-6.24,12-58.32L586.22,8h46.2V92H619V24.44H598.82l-0.12,3.12C597.14,81,589,94.4,573.74,94.4a28.55,28.55,0,0,1-6.72-.84Z"
-    >
-      <animateTransform
-        id="lAppear"
-        attributeName="transform"
-        type="translate"
-        begin="a2Appear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="lAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="l" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M568.7,76.88a13.77,13.77,0,0,0,5,1c6.6,0,10.44-6.24,12-58.32L586.22,8h46.2V92H619V24.44H598.82l-0.12,3.12C597.14,81,589,94.4,573.74,94.4a28.55,28.55,0,0,1-6.72-.84Z"/>
     <path
-      id="exclamation" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
-      d="M646.1,70.4L647.54,2H661l1.44,68.4H646.1Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,0,1-16.08,0C646.34,80,649.58,76.76,654.38,76.76Z"
-    >
-      <animateTransform
-        id="exclAppear"
-        attributeName="transform"
-        type="translate"
-        begin="lAppear.end-550ms"
-        dur="600ms"
-        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
-        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
-        calcMode="spline"
-        fill="freeze"/>
-      <animate
-        attributeName="stroke-dasharray"
-        from="1 100" to="100 0"
-        begin="exclAppear.begin-100ms"
-        dur="300ms"
-        fill="freeze"/>
-    </path>
+      id="exclamation" class="letter" transform="translate(-2.16 0)" fill="none" stroke="currentColor"
+      d="M646.1,70.4L647.54,2H661l1.44,68.4H646.1Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,0,1-16.08,0C646.34,80,649.58,76.76,654.38,76.76Z"/>
   </g>
 </svg>

--- a/source/img/lose-heading.svg
+++ b/source/img/lose-heading.svg
@@ -1,25 +1,193 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660.77 109.24">
-  <path d="M2.66,92V8H16.1V42.2H53.3V8H66.74V92H53.3V58.64H16.1V92H2.66Z" transform="translate(-2.16 -1.5)"
-        fill="none" stroke="currentColor"/>
-  <path d="M147.62,8V24.44H97V41.6h33.6V58H97V75.56h50.64V92H83.54V8h64.08Z" transform="translate(-2.16 -1.5)"
-        fill="none" stroke="currentColor"/>
-  <path d="M199.22,8l20.52,42.36L235.34,8h16.44l-31,84H204.38l9.48-25.92L185.78,8h13.44Z"
-        transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-  <path d="M273.74,24.44V92H260.3V8h50.16V24.44H273.74Z" transform="translate(-2.16 -1.5)" fill="none"
-        stroke="currentColor"/>
-  <path
-    d="M307.1,92l28-84h27.12l28.08,84H376.82L369,68.48h-37.8L323.42,92H307.1Zm56.64-40L350.3,11.84,336.86,52h26.88Z"
-    transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M396.38,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L412.94,8h48.6V75.56h10v34.68H456.86V92H411v18.24H396.38ZM448.1,75.56V24.44H425.54v3.12c-0.48,22.44-3.24,37.68-7.2,48H448.1Z"
-    transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M477.74,92l28-84h27.12L560.9,92H547.46l-7.8-23.52h-37.8L494.06,92H477.74Zm56.64-40-13.44-40.2L507.5,52h26.88Z"
-    transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M568.7,76.88a13.77,13.77,0,0,0,5,1c6.6,0,10.44-6.24,12-58.32L586.22,8h46.2V92H619V24.44H598.82l-0.12,3.12C597.14,81,589,94.4,573.74,94.4a28.55,28.55,0,0,1-6.72-.84Z"
-    transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M646.1,70.4L647.54,2H661l1.44,68.4H646.1Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,0,1-16.08,0C646.34,80,649.58,76.76,654.38,76.76Z"
-    transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660 220" width="660" height="220">
+  <g>
+    <path
+      id="n" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M2.66,92V8H16.1V42.2H53.3V8H66.74V92H53.3V58.64H16.1V92H2.66Z"
+    >
+      <animateTransform
+        id="nAppear"
+        attributeName="transform"
+        type="translate"
+        begin="100ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="nAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="e" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M147.62,8V24.44H97V41.6h33.6V58H97V75.56h50.64V92H83.54V8h64.08Z"
+    >
+      <animateTransform
+        id="eAppear"
+        attributeName="transform"
+        type="translate"
+        begin="nAppear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="eAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="u" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M199.22,8l20.52,42.36L235.34,8h16.44l-31,84H204.38l9.48-25.92L185.78,8h13.44Z"
+    >
+      <animateTransform
+        id="uAppear"
+        attributeName="transform"
+        type="translate"
+        begin="eAppear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="uAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="g" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M273.74,24.44V92H260.3V8h50.16V24.44H273.74Z"
+    >
+      <animateTransform
+        id="gAppear"
+        attributeName="transform"
+        type="translate"
+        begin="uAppear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="gAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="a1" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M307.1,92l28-84h27.12l28.08,84H376.82L369,68.48h-37.8L323.42,92H307.1Zm56.64-40L350.3,11.84,336.86,52h26.88Z"
+    >
+      <animateTransform
+        id="a1Appear"
+        attributeName="transform"
+        type="translate"
+        begin="gAppear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="a1Appear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="d" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M396.38,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L412.94,8h48.6V75.56h10v34.68H456.86V92H411v18.24H396.38ZM448.1,75.56V24.44H425.54v3.12c-0.48,22.44-3.24,37.68-7.2,48H448.1Z"
+    >
+      <animateTransform
+        id="dAppear"
+        attributeName="transform"
+        type="translate"
+        begin="a1Appear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="dAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="a2" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M477.74,92l28-84h27.12L560.9,92H547.46l-7.8-23.52h-37.8L494.06,92H477.74Zm56.64-40-13.44-40.2L507.5,52h26.88Z"
+    >
+      <animateTransform
+        id="a2Appear"
+        attributeName="transform"
+        type="translate"
+        begin="dAppear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="a2Appear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="l" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M568.7,76.88a13.77,13.77,0,0,0,5,1c6.6,0,10.44-6.24,12-58.32L586.22,8h46.2V92H619V24.44H598.82l-0.12,3.12C597.14,81,589,94.4,573.74,94.4a28.55,28.55,0,0,1-6.72-.84Z"
+    >
+      <animateTransform
+        id="lAppear"
+        attributeName="transform"
+        type="translate"
+        begin="a2Appear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="lAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+    <path
+      id="exclamation" transform="translate(-2.16 0)" fill="none" stroke="currentColor" stroke-dasharray="1 100"
+      d="M646.1,70.4L647.54,2H661l1.44,68.4H646.1Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,0,1-16.08,0C646.34,80,649.58,76.76,654.38,76.76Z"
+    >
+      <animateTransform
+        id="exclAppear"
+        attributeName="transform"
+        type="translate"
+        begin="lAppear.end-550ms"
+        dur="600ms"
+        values="-2.16 0; -2.16 110; -2.16 95; -2.16 110"
+        keySplines="0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45"
+        calcMode="spline"
+        fill="freeze"/>
+      <animate
+        attributeName="stroke-dasharray"
+        from="1 100" to="100 0"
+        begin="exclAppear.begin-100ms"
+        dur="300ms"
+        fill="freeze"/>
+    </path>
+  </g>
 </svg>

--- a/source/img/win-heading.svg
+++ b/source/img/win-heading.svg
@@ -1,20 +1,47 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 568.85 109.24">
-  <path d="M16,24.44V92H2.6V8H75V92H61.52V24.44H16Z" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M148.76,5.6c32.88,0,59.52,19.92,59.52,44.4s-26.64,44.4-59.52,44.4S89.24,74.48,89.24,50,115.88,5.6,148.76,5.6Zm0,72.12c24.48,0,44.4-12.36,44.4-27.72s-19.92-27.84-44.4-27.84C124,22.16,104,34.52,104,50S124,77.72,148.76,77.72Z"
-    transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M287.36,8V24.44H236v14.4h25.32c25.44,0,34,11.16,34,26.52,0,15.6-8.52,26.64-34,26.64H222.56V8h64.8ZM256.88,76.52c15.12,0,23.52-2,23.52-11.52S272,54.44,256.88,54.44H236V76.52h20.88Z"
-    transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-  <path d="M371.47,8V24.44H320.84V41.6h33.6V58h-33.6V75.56h50.64V92H307.4V8h64.08Z" transform="translate(-2.1 -1.5)"
-        fill="none" stroke="currentColor"/>
-  <path
-    d="M382.39,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L399,8h48.6V75.56h10v34.68H442.87V92H397v18.24H382.39Zm51.72-34.68V24.44H411.55v3.12c-0.48,22.44-3.24,37.68-7.2,48h29.76Z"
-    transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M463.75,92l28-84h27.12l28.08,84H533.47l-7.8-23.52h-37.8L480.07,92H463.75Zm56.64-40L507,11.84,493.51,52h26.88Z"
-    transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-  <path
-    d="M554.12,70.4L555.55,2H569l1.44,68.4H554.12Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,1,1-16.08,0C554.35,80,557.59,76.76,562.39,76.76Z"
-    transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
+  <g>
+    <path
+      id="p" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M16,24.44V92H2.6V8H75V92H61.52V24.44H16Z"/>
+    <path
+      id="o" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M148.76,5.6c32.88,0,59.52,19.92,59.52,44.4s-26.64,44.4-59.52,44.4S89.24,74.48,89.24,50,115.88,5.6,148.76,5.6Zm0,72.12c24.48,0,44.4-12.36,44.4-27.72s-19.92-27.84-44.4-27.84C124,22.16,104,34.52,104,50S124,77.72,148.76,77.72Z"/>
+    <path
+      id="b" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M287.36,8V24.44H236v14.4h25.32c25.44,0,34,11.16,34,26.52,0,15.6-8.52,26.64-34,26.64H222.56V8h64.8ZM256.88,76.52c15.12,0,23.52-2,23.52-11.52S272,54.44,256.88,54.44H236V76.52h20.88Z"/>
+    <path
+      id="e" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M371.47,8V24.44H320.84V41.6h33.6V58h-33.6V75.56h50.64V92H307.4V8h64.08Z"/>
+    <path
+      id="d" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M382.39,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L399,8h48.6V75.56h10v34.68H442.87V92H397v18.24H382.39Zm51.72-34.68V24.44H411.55v3.12c-0.48,22.44-3.24,37.68-7.2,48h29.76Z"/>
+    <path
+      id="a" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M463.75,92l28-84h27.12l28.08,84H533.47l-7.8-23.52h-37.8L480.07,92H463.75Zm56.64-40L507,11.84,493.51,52h26.88Z"/>
+    <path
+      id="exclamation" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      d="M554.12,70.4L555.55,2H569l1.44,68.4H554.12Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,1,1-16.08,0C554.35,80,557.59,76.76,562.39,76.76Z"/>
+    <animateTransform
+      id="appear"
+      attributeName="transform"
+      type="scale"
+      from="1 1" to="0.9 0.9"
+      begin="0s"
+      dur="250ms"
+      fill="freeze"/>
+    <animateTransform
+      attributeName="transform"
+      type="translate"
+      from="0 0" to="30 5"
+      begin="appear.begin"
+      dur="250ms"
+      additive="sum"
+      fill="freeze"/>
+    <animate
+      attributeName="stroke-dasharray"
+      from="1 100" to="100 0"
+      begin="appear.begin"
+      dur="500ms"
+      fill="freeze"/>
+  </g>
 </svg>

--- a/source/img/win-heading.svg
+++ b/source/img/win-heading.svg
@@ -1,47 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 568.85 109.24">
-  <g>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 568.85 109.24" width="569" height="110">
+  <g class="positiveHeading">
     <path
-      id="p" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="p" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M16,24.44V92H2.6V8H75V92H61.52V24.44H16Z"/>
     <path
-      id="o" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="o" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M148.76,5.6c32.88,0,59.52,19.92,59.52,44.4s-26.64,44.4-59.52,44.4S89.24,74.48,89.24,50,115.88,5.6,148.76,5.6Zm0,72.12c24.48,0,44.4-12.36,44.4-27.72s-19.92-27.84-44.4-27.84C124,22.16,104,34.52,104,50S124,77.72,148.76,77.72Z"/>
     <path
-      id="b" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="b" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M287.36,8V24.44H236v14.4h25.32c25.44,0,34,11.16,34,26.52,0,15.6-8.52,26.64-34,26.64H222.56V8h64.8ZM256.88,76.52c15.12,0,23.52-2,23.52-11.52S272,54.44,256.88,54.44H236V76.52h20.88Z"/>
     <path
-      id="e" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="e" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M371.47,8V24.44H320.84V41.6h33.6V58h-33.6V75.56h50.64V92H307.4V8h64.08Z"/>
     <path
-      id="d" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="d" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M382.39,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L399,8h48.6V75.56h10v34.68H442.87V92H397v18.24H382.39Zm51.72-34.68V24.44H411.55v3.12c-0.48,22.44-3.24,37.68-7.2,48h29.76Z"/>
     <path
-      id="a" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="a" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M463.75,92l28-84h27.12l28.08,84H533.47l-7.8-23.52h-37.8L480.07,92H463.75Zm56.64-40L507,11.84,493.51,52h26.88Z"/>
     <path
-      id="exclamation" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
+      id="exclamation" class="letter" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"
       d="M554.12,70.4L555.55,2H569l1.44,68.4H554.12Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,1,1-16.08,0C554.35,80,557.59,76.76,562.39,76.76Z"/>
-    <animateTransform
-      id="appear"
-      attributeName="transform"
-      type="scale"
-      from="1 1" to="0.9 0.9"
-      begin="0s"
-      dur="250ms"
-      fill="freeze"/>
-    <animateTransform
-      attributeName="transform"
-      type="translate"
-      from="0 0" to="30 5"
-      begin="appear.begin"
-      dur="250ms"
-      additive="sum"
-      fill="freeze"/>
-    <animate
-      attributeName="stroke-dasharray"
-      from="1 100" to="100 0"
-      begin="appear.begin"
-      dur="500ms"
-      fill="freeze"/>
   </g>
 </svg>

--- a/source/index.html
+++ b/source/index.html
@@ -353,26 +353,7 @@
           </div>
           <h2 class="result__title">
             <span class="visually-hidden">ПОбеда!</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 568.85 109.24">
-              <path d="M16,24.44V92H2.6V8H75V92H61.52V24.44H16Z" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M148.76,5.6c32.88,0,59.52,19.92,59.52,44.4s-26.64,44.4-59.52,44.4S89.24,74.48,89.24,50,115.88,5.6,148.76,5.6Zm0,72.12c24.48,0,44.4-12.36,44.4-27.72s-19.92-27.84-44.4-27.84C124,22.16,104,34.52,104,50S124,77.72,148.76,77.72Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M287.36,8V24.44H236v14.4h25.32c25.44,0,34,11.16,34,26.52,0,15.6-8.52,26.64-34,26.64H222.56V8h64.8ZM256.88,76.52c15.12,0,23.52-2,23.52-11.52S272,54.44,256.88,54.44H236V76.52h20.88Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path d="M371.47,8V24.44H320.84V41.6h33.6V58h-33.6V75.56h50.64V92H307.4V8h64.08Z" transform="translate(-2.1 -1.5)"
-                    fill="none" stroke="currentColor"/>
-              <path
-                d="M382.39,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L399,8h48.6V75.56h10v34.68H442.87V92H397v18.24H382.39Zm51.72-34.68V24.44H411.55v3.12c-0.48,22.44-3.24,37.68-7.2,48h29.76Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M463.75,92l28-84h27.12l28.08,84H533.47l-7.8-23.52h-37.8L480.07,92H463.75Zm56.64-40L507,11.84,493.51,52h26.88Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M554.12,70.4L555.55,2H569l1.44,68.4H554.12Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,1,1-16.08,0C554.35,80,557.59,76.76,562.39,76.76Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-            </svg>
+            <include src="img/win-heading.svg"></include>
           </h2>
           <div class="result__text">
             <p>ты&nbsp;отправляешься в&nbsp;Арктику!</p>
@@ -405,26 +386,7 @@
           </div>
           <h2 class="result__title">
             <span class="visually-hidden">ПОбеда!</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 568.85 109.24">
-              <path d="M16,24.44V92H2.6V8H75V92H61.52V24.44H16Z" transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M148.76,5.6c32.88,0,59.52,19.92,59.52,44.4s-26.64,44.4-59.52,44.4S89.24,74.48,89.24,50,115.88,5.6,148.76,5.6Zm0,72.12c24.48,0,44.4-12.36,44.4-27.72s-19.92-27.84-44.4-27.84C124,22.16,104,34.52,104,50S124,77.72,148.76,77.72Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M287.36,8V24.44H236v14.4h25.32c25.44,0,34,11.16,34,26.52,0,15.6-8.52,26.64-34,26.64H222.56V8h64.8ZM256.88,76.52c15.12,0,23.52-2,23.52-11.52S272,54.44,256.88,54.44H236V76.52h20.88Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path d="M371.47,8V24.44H320.84V41.6h33.6V58h-33.6V75.56h50.64V92H307.4V8h64.08Z" transform="translate(-2.1 -1.5)"
-                    fill="none" stroke="currentColor"/>
-              <path
-                d="M382.39,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L399,8h48.6V75.56h10v34.68H442.87V92H397v18.24H382.39Zm51.72-34.68V24.44H411.55v3.12c-0.48,22.44-3.24,37.68-7.2,48h29.76Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M463.75,92l28-84h27.12l28.08,84H533.47l-7.8-23.52h-37.8L480.07,92H463.75Zm56.64-40L507,11.84,493.51,52h26.88Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M554.12,70.4L555.55,2H569l1.44,68.4H554.12Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,1,1-16.08,0C554.35,80,557.59,76.76,562.39,76.76Z"
-                transform="translate(-2.1 -1.5)" fill="none" stroke="currentColor"/>
-            </svg>
+            <include src="img/win-heading.svg"></include>
           </h2>
           <div class="result__text">
             <p>чемодан &laquo;Fjord&nbsp;Inc.&raquo;&nbsp;твой</p>
@@ -457,31 +419,7 @@
           </div>
           <h2 class="result__title">
             <span class="visually-hidden">Не угадал!</span>
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 660.77 109.24">
-              <path d="M2.66,92V8H16.1V42.2H53.3V8H66.74V92H53.3V58.64H16.1V92H2.66Z" transform="translate(-2.16 -1.5)"
-                    fill="none" stroke="currentColor"/>
-              <path d="M147.62,8V24.44H97V41.6h33.6V58H97V75.56h50.64V92H83.54V8h64.08Z" transform="translate(-2.16 -1.5)"
-                    fill="none" stroke="currentColor"/>
-              <path d="M199.22,8l20.52,42.36L235.34,8h16.44l-31,84H204.38l9.48-25.92L185.78,8h13.44Z"
-                    transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-              <path d="M273.74,24.44V92H260.3V8h50.16V24.44H273.74Z" transform="translate(-2.16 -1.5)" fill="none"
-                    stroke="currentColor"/>
-              <path
-                d="M307.1,92l28-84h27.12l28.08,84H376.82L369,68.48h-37.8L323.42,92H307.1Zm56.64-40L350.3,11.84,336.86,52h26.88Z"
-                transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M396.38,110.24V75.56h7.44c4.56-4.68,7.8-18.36,8.76-56L412.94,8h48.6V75.56h10v34.68H456.86V92H411v18.24H396.38ZM448.1,75.56V24.44H425.54v3.12c-0.48,22.44-3.24,37.68-7.2,48H448.1Z"
-                transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M477.74,92l28-84h27.12L560.9,92H547.46l-7.8-23.52h-37.8L494.06,92H477.74Zm56.64-40-13.44-40.2L507.5,52h26.88Z"
-                transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M568.7,76.88a13.77,13.77,0,0,0,5,1c6.6,0,10.44-6.24,12-58.32L586.22,8h46.2V92H619V24.44H598.82l-0.12,3.12C597.14,81,589,94.4,573.74,94.4a28.55,28.55,0,0,1-6.72-.84Z"
-                transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-              <path
-                d="M646.1,70.4L647.54,2H661l1.44,68.4H646.1Zm8.28,6.36c4.8,0,8,3.24,8,8.16a8,8,0,0,1-16.08,0C646.34,80,649.58,76.76,654.38,76.76Z"
-                transform="translate(-2.16 -1.5)" fill="none" stroke="currentColor"/>
-            </svg>
+            <include src="img/lose-heading.svg"></include>
           </h2>
           <button class="result__button js-play" type="button">
             не сдавайся!

--- a/source/js/additions/result-animation.js
+++ b/source/js/additions/result-animation.js
@@ -1,0 +1,164 @@
+export default () => {
+  const DRAWING_PARTS = 3;
+  const DRAWING_DURATION = `500ms`;
+
+  const FALLING_VALUES = `-2.16 0; -2.16 110; -2.16 95; -2.16 110`;
+  const FALLING_SPLINES = `0.55 0 1 0.45; 0.25 1 0.5 1; 0.55 0 1 0.45`;
+  const FALLING_DELAY = `50ms`;
+  const FALLING_DURATION = `500ms`;
+
+  const APPEAR_SCALE_FROM = `1 1`;
+  const APPEAR_SCALE_TO = `0.9 0.9`;
+  const APPEAR_SCALE_DURATION = `250ms`;
+
+  const APPEAR_TRANSLATE_FROM = `0 0`;
+  const APPEAR_TRANSLATE_TO = `30 5`;
+  const APPEAR_TRANSLATE_DURATION = `250ms`;
+
+  const ANIMATION_ID_POSTFIX = `Appear`;
+
+  /**
+   * Создает SMIL-анимацию рисования контура и возвращает DOM-узел, который
+   * нужно вставить в качестве потомка для объекта анимации.
+   * @param  {string} begin       Время начала анимации, соответствует атрибуту
+   *                              begin для <animate>.
+   * @param  {[type]} strokeWidth Длина контура расчетного контура. В этот
+   *                              атрибут лучше всего передавать результат
+   *                              метода getTotalLength().
+   * @return {element}            Узел <animate>, готовый для интеграции
+   *                              с помощью appendChild().
+   */
+  const makeDrawingAnimation = function (begin, strokeWidth) {
+    const animate = document.createElementNS(`http://www.w3.org/2000/svg`, `animate`);
+    animate.setAttribute(`attributeName`, `stroke-dasharray`);
+    animate.setAttribute(`class`, `positiveHeadingAppear`);
+    animate.setAttribute(`from`, `0 ` + Math.ceil(strokeWidth / DRAWING_PARTS));
+    animate.setAttribute(`to`, Math.ceil(strokeWidth / DRAWING_PARTS) + ` 0`);
+    animate.setAttribute(`begin`, begin);
+    animate.setAttribute(`dur`, DRAWING_DURATION);
+    animate.setAttribute(`fill`, `freeze`);
+    return animate;
+  };
+
+  /**
+   * Создает SMIL-анимацию падения объекта и возвращает DOM-узел, который
+   * нужно вставить в качестве потомка для объекта анимации.
+   * @param  {string} begin       Время начала анимации, соответствует атрибуту
+   *                              begin для <animate>.
+   * @return {element}            Узел <animate>, готовый для интеграции
+   *                              с помощью appendChild().
+   */
+  const makeFallingAnimation = function (begin) {
+    const animate = document.createElementNS(`http://www.w3.org/2000/svg`, `animateTransform`);
+    animate.setAttribute(`attributeName`, `transform`);
+    animate.setAttribute(`type`, `translate`);
+    animate.setAttribute(`begin`, begin);
+    animate.setAttribute(`dur`, FALLING_DURATION);
+    animate.setAttribute(`values`, FALLING_VALUES);
+    animate.setAttribute(`keySplines`, FALLING_SPLINES);
+    animate.setAttribute(`calcMode`, `spline`);
+    animate.setAttribute(`fill`, `freeze`);
+    return animate;
+  };
+
+  /**
+   * Создает SMIL-анимацию появления заголовка победы.
+   * @param  {string} selector CSS-селектор блока с SVG-изображением внутри
+   *                           (не обязательно само изображение).
+   * @param  {string} id       ID первой анимации
+   * @return {void}
+   */
+  const assignPositiveAnimation = function (selector, id) {
+    const heading = document.querySelector(selector + ` .positiveHeading`);
+
+    const scale = document.createElementNS(`http://www.w3.org/2000/svg`, `animateTransform`);
+    scale.setAttribute(`id`, id + ANIMATION_ID_POSTFIX);
+    scale.setAttribute(`attributeName`, `transform`);
+    scale.setAttribute(`type`, `scale`);
+    scale.setAttribute(`from`, APPEAR_SCALE_FROM);
+    scale.setAttribute(`to`, APPEAR_SCALE_TO);
+    scale.setAttribute(`begin`, `indefinite`);
+    scale.setAttribute(`dur`, APPEAR_SCALE_DURATION);
+    scale.setAttribute(`fill`, `freeze`);
+    heading.appendChild(scale);
+
+    const translate = document.createElementNS(`http://www.w3.org/2000/svg`, `animateTransform`);
+    translate.setAttribute(`attributeName`, `transform`);
+    translate.setAttribute(`type`, `translate`);
+    translate.setAttribute(`from`, APPEAR_TRANSLATE_FROM);
+    translate.setAttribute(`to`, APPEAR_TRANSLATE_TO);
+    translate.setAttribute(`begin`, id + ANIMATION_ID_POSTFIX + `.begin`);
+    translate.setAttribute(`dur`, APPEAR_TRANSLATE_DURATION);
+    translate.setAttribute(`additive`, `sum`);
+    translate.setAttribute(`fill`, `freeze`);
+    heading.appendChild(translate);
+
+    const letters = heading.querySelectorAll(`.letter`);
+    letters.forEach((element) => {
+      element.appendChild(makeDrawingAnimation(id + `Appear.begin`, element.getTotalLength()));
+    });
+  };
+
+  /**
+   * Создает SMIL-анимацию появления заголовка поражения.
+   * @param  {string} selector CSS-селектор блока с SVG-изображением внутри
+   *                           (не обязательно само изображение).
+   * @param  {string} id       ID первой анимации
+   * @return {void}
+   */
+  const assignNegativeAnimation = function (selector, id) {
+    const heading = document.querySelector(selector + ` .negativeHeading`);
+
+    let previousAnimation = id + ANIMATION_ID_POSTFIX;
+
+    const dummy = document.createElementNS(`http://www.w3.org/2000/svg`, `animate`);
+    dummy.setAttribute(`id`, previousAnimation);
+    dummy.setAttribute(`attributeName`, `opacity`);
+    dummy.setAttribute(`from`, 0);
+    dummy.setAttribute(`to`, 1);
+    dummy.setAttribute(`begin`, `indefinite`);
+    dummy.setAttribute(`dur`, `1ms`);
+    heading.appendChild(dummy);
+
+    const letters = heading.querySelectorAll(`.letter`);
+    letters.forEach((element) => {
+      const letterId = element.id;
+      const pathLength = element.getTotalLength();
+      const falligAnimation = makeFallingAnimation(previousAnimation + `.begin+` + FALLING_DELAY);
+      const drawingAnimation = makeDrawingAnimation(previousAnimation + `.begin`, pathLength);
+      previousAnimation = letterId + ANIMATION_ID_POSTFIX;
+      falligAnimation.setAttribute(`id`, previousAnimation);
+
+      element.setAttribute(`stroke-dasharray`, `0 ` + Math.ceil(pathLength / DRAWING_PARTS));
+      element.appendChild(falligAnimation);
+      element.appendChild(drawingAnimation);
+    });
+  };
+
+  // Добавление анимации сообщения о главном призе
+  const tripHeadingId = `tripHeading`;
+  const tripResult = document.querySelector(`.js-show-result[data-target=result]`);
+  assignPositiveAnimation(`.result--trip`, tripHeadingId);
+  tripResult.addEventListener(`click`, () => {
+    const tripHeadingAppear = document.querySelector(`#` + tripHeadingId + ANIMATION_ID_POSTFIX);
+    tripHeadingAppear.beginElement();
+  });
+
+  // Добавление анимации сообщения о второстепенном призе
+  const prizeHeadingId = `prizeHeading`;
+  const prizeResult = document.querySelector(`.js-show-result[data-target=result2]`);
+  assignPositiveAnimation(`.result--prize`, prizeHeadingId);
+  prizeResult.addEventListener(`click`, () => {
+    const prizeHeadingAppear = document.querySelector(`#` + prizeHeadingId + ANIMATION_ID_POSTFIX);
+    prizeHeadingAppear.beginElement();
+  });
+
+  // Добавление анимации сообщения об отсутствии приза
+  const negativeHeadingId = `negativeHeading`;
+  const negativeResult = document.querySelector(`.js-show-result[data-target=result3]`);
+  assignNegativeAnimation(`.result--negative`, negativeHeadingId);
+  negativeResult.addEventListener(`click`, () => {
+    const negativeHeadingAppear = document.querySelector(`#` + negativeHeadingId + ANIMATION_ID_POSTFIX);
+    negativeHeadingAppear.beginElement();
+  });
+};

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -31,9 +31,11 @@ import socialOnFocus from './additions/social-on-focus.js';
 import changeScreens from './additions/change-screens.js';
 import rulesButton from './additions/rules-button.js';
 import ripple from './additions/ripple.js';
+import resultAnimation from './additions/result-animation.js';
 
 bodyload();
 socialOnFocus();
 changeScreens();
 rulesButton();
 ripple();
+resultAnimation();

--- a/source/scss/additions/blocks/prizes.scss
+++ b/source/scss/additions/blocks/prizes.scss
@@ -148,3 +148,7 @@
     padding-bottom: 2rem;
   }
 }
+
+.game__buttons {
+  display: block;
+}

--- a/source/scss/additions/blocks/result.scss
+++ b/source/scss/additions/blocks/result.scss
@@ -1,0 +1,28 @@
+.result--negative {
+  .result__title {
+    margin-top: -1.8rem;
+    width: 66.5rem;
+    height: 22.6rem;
+
+    @media (min-width: $stop-scaling) {
+      margin-top: -18px;
+      width: 665px;
+      height: 226px;
+    }
+
+    @media (orientation: portrait) {
+      margin-top: -4.9rem;
+      width: 28.8rem;
+      height: 9.8rem;
+    }
+
+    @media (max-width: $tablet) and (orientation: landscape) {
+      margin-top: 0;
+      width: 50rem;
+    }
+
+    @media (max-width: $mobile) and (orientation: landscape) {
+      width: 45rem;
+    }
+  }
+}

--- a/source/scss/additions/style.scss
+++ b/source/scss/additions/style.scss
@@ -5,6 +5,7 @@
 @import "blocks/intro.scss";
 @import "blocks/page-header.scss";
 @import "blocks/prizes.scss";
+@import "blocks/result.scss";
 @import "blocks/ripple.scss";
 @import "blocks/rules.scss";
 @import "blocks/screen.scss";


### PR DESCRIPTION
**Добавлена анимация заголовков победы и проигрыша**

Саму анимацию можно пока увидеть только в svg-файлах, т.к. я не понял, можно ли вообще сейчас вызвать победу или поражение на самом сайте. Если все-таки можно, то следует иметь в виду, что высота холста заголовка поражения увеличена в два раза, чтобы обеспечить анимацию падения букв.

---
:mortar_board: [Реализовываем анимацию заголовков на экране «Результат игры»](https://up.htmlacademy.ru/animation/1/user/1339161/tasks/12)

:boom: https://htmlacademy-animation.github.io/1339161-magic-vacation-1/10/